### PR TITLE
Fix critical issues in parser and DB writer

### DIFF
--- a/bot/Database/database.go
+++ b/bot/Database/database.go
@@ -108,22 +108,34 @@ func (w *DBWriter) commitBatch() {
 	}
 
 	for _, req := range w.batch {
+		var wErr error
 		switch req.Type {
 		case SaveTokenRequest:
-			w.saveToken(tx, req.Token)
+			wErr = w.saveToken(tx, req.Token)
 		case SavePoolRequest:
-			w.savePool(tx, req.Pool)
+			wErr = w.savePool(tx, req.Pool)
 		case SaveV2SwapRequest:
-			w.saveV2Swap(tx, req.V2Swap)
+			wErr = w.saveV2Swap(tx, req.V2Swap)
 		case SaveV3SwapRequest:
-			w.saveV3Swap(tx, req.V3Swap)
+			wErr = w.saveV3Swap(tx, req.V3Swap)
 		case SaveOpportunityRequest:
-			w.saveArbitrageOpportunity(tx, req.Opportunity)
+			wErr = w.saveArbitrageOpportunity(tx, req.Opportunity)
+		}
+		if wErr != nil {
+			log.Printf("DB Writer: Rolling back transaction due to error: %v", wErr)
+			if rbErr := tx.Rollback(); rbErr != nil {
+				log.Printf("DB Writer: Error during rollback: %v", rbErr)
+			}
+			w.batch = w.batch[:0]
+			return
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
 		log.Printf("DB Writer: Error committing transaction: %v", err)
+		if rbErr := tx.Rollback(); rbErr != nil {
+			log.Printf("DB Writer: Error during rollback: %v", rbErr)
+		}
 	}
 	w.batch = w.batch[:0] // Clear the batch
 }
@@ -234,44 +246,49 @@ func (w *DBWriter) LoadInitialData() ([]PoolRecord, []TokenRecord, error) {
 }
 
 // saveToken, savePool, etc., now operate on a transaction.
-func (w *DBWriter) saveToken(tx *sql.Tx, token *TokenRecord) {
+func (w *DBWriter) saveToken(tx *sql.Tx, token *TokenRecord) error {
 	stmt := `INSERT OR IGNORE INTO tokens (address, symbol, decimals) VALUES (?, ?, ?)`
 	_, err := tx.Exec(stmt, strings.ToLower(token.Address), token.Symbol, token.Decimals)
 	if err != nil {
-		log.Printf("DB Writer: Error saving token %s: %v", token.Address, err)
+		return fmt.Errorf("error saving token %s: %w", token.Address, err)
 	}
+	return nil
 }
 
-func (w *DBWriter) savePool(tx *sql.Tx, pool *PoolRecord) {
+func (w *DBWriter) savePool(tx *sql.Tx, pool *PoolRecord) error {
 	stmt := `INSERT OR IGNORE INTO pools (address, protocol, factory, fee, address_ticker, symbol_ticker, token0_address, token1_address) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := tx.Exec(stmt, strings.ToLower(pool.Address), pool.Protocol, pool.Factory, pool.Fee, pool.AddressTicker, pool.SymbolTicker, strings.ToLower(pool.Token0Address), strings.ToLower(pool.Token1Address))
 	if err != nil {
-		log.Printf("DB Writer: Error saving pool %s: %v", pool.Address, err)
+		return fmt.Errorf("error saving pool %s: %w", pool.Address, err)
 	}
+	return nil
 }
 
-func (w *DBWriter) saveV2Swap(tx *sql.Tx, record *V2SwapRecord) {
+func (w *DBWriter) saveV2Swap(tx *sql.Tx, record *V2SwapRecord) error {
 	stmt := `INSERT OR IGNORE INTO v2_swaps (tx_hash, log_index, pool_address, sender, recipient, amount0_in, amount1_in, amount0_out, amount1_out) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := tx.Exec(stmt, record.TxHash.Hex(), record.LogIndex, record.PoolAddress.Hex(), record.Swap.Sender.Hex(), record.Swap.To.Hex(), record.Swap.Amount0In.String(), record.Swap.Amount1In.String(), record.Swap.Amount0Out.String(), record.Swap.Amount1Out.String())
 	if err != nil {
-		log.Printf("DB Writer: Error saving V2 swap for tx %s: %v", record.TxHash.Hex(), err)
+		return fmt.Errorf("error saving V2 swap for tx %s: %w", record.TxHash.Hex(), err)
 	}
+	return nil
 }
 
-func (w *DBWriter) saveV3Swap(tx *sql.Tx, record *V3SwapRecord) {
+func (w *DBWriter) saveV3Swap(tx *sql.Tx, record *V3SwapRecord) error {
 	stmt := `INSERT OR IGNORE INTO v3_swaps (tx_hash, log_index, pool_address, sender, recipient, amount0, amount1, tick) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := tx.Exec(stmt, record.TxHash.Hex(), record.LogIndex, record.PoolAddress.Hex(), record.Swap.Sender.Hex(), record.Swap.Recipient.Hex(), record.Swap.Amount0.String(), record.Swap.Amount1.String(), record.Swap.Tick.String())
 	if err != nil {
-		log.Printf("DB Writer: Error saving V3 swap for tx %s: %v", record.TxHash.Hex(), err)
+		return fmt.Errorf("error saving V3 swap for tx %s: %w", record.TxHash.Hex(), err)
 	}
+	return nil
 }
 
-func (w *DBWriter) saveArbitrageOpportunity(tx *sql.Tx, op *Opportunity) {
+func (w *DBWriter) saveArbitrageOpportunity(tx *sql.Tx, op *Opportunity) error {
 	stmt := `INSERT INTO arbitrage_opportunities (symbol_ticker, pool_a_address, pool_a_protocol, pool_a_factory, pool_a_price, pool_a_fee, pool_b_address, pool_b_protocol, pool_b_factory, pool_b_price, pool_b_fee, percent_diff, token0_address, token1_address, token0_symbol, token1_symbol) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := tx.Exec(stmt, op.SymbolTicker, op.PoolA.Address, op.PoolA.Protocol, op.PoolA.Factory, op.PoolA.Price, op.PoolA.Fee, op.PoolB.Address, op.PoolB.Protocol, op.PoolB.Factory, op.PoolB.Price, op.PoolB.Fee, op.PercentDiff, op.Token0Address, op.Token1Address, op.Token0Symbol, op.Token1Symbol)
 	if err != nil {
-		log.Printf("DB Writer: Error saving arbitrage opportunity for ticker %s: %v", op.SymbolTicker, err)
+		return fmt.Errorf("error saving arbitrage opportunity for ticker %s: %w", op.SymbolTicker, err)
 	}
+	return nil
 }
 
 // Structs for DB records, kept internal to the package.

--- a/bot/Database/database_test.go
+++ b/bot/Database/database_test.go
@@ -1,0 +1,27 @@
+package Database
+
+import (
+	"testing"
+)
+
+func TestDBWriterCommitBatch(t *testing.T) {
+	writer, err := NewDBWriter(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create DBWriter: %v", err)
+	}
+
+	writer.batch = append(writer.batch, &DBWriteRequest{
+		Type:  SaveTokenRequest,
+		Token: &TokenRecord{Address: "0x1", Symbol: "TST", Decimals: 18},
+	})
+	writer.commitBatch()
+
+	row := writer.db.QueryRow("SELECT symbol FROM tokens WHERE address = ?", "0x1")
+	var symbol string
+	if err := row.Scan(&symbol); err != nil {
+		t.Fatalf("token not inserted: %v", err)
+	}
+	if symbol != "TST" {
+		t.Fatalf("unexpected symbol: %s", symbol)
+	}
+}

--- a/bot/Parser/Parser.go
+++ b/bot/Parser/Parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -11,8 +12,10 @@ import (
 )
 
 var (
-	V2ABI abi.ABI
-	V3ABI abi.ABI
+	V2ABI    abi.ABI
+	V3ABI    abi.ABI
+	initOnce sync.Once
+	initErr  error
 )
 
 // Service holds the ABIs for parsing.
@@ -20,19 +23,31 @@ type Service struct{}
 
 // NewService creates a new Parser service.
 func NewService() (*Service, error) {
-	var err error
-	v2AbiString := `[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"sender","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount0In","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"amount1In","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"amount0Out","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"amount1Out","type":"uint256"},{"indexed":true,"internalType":"address","name":"to","type":"address"}],"name":"Swap","type":"event"}]`
-	v3AbiString := `[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"sender","type":"address"},{"indexed":true,"internalType":"address","name":"recipient","type":"address"},{"indexed":false,"internalType":"int256","name":"amount0","type":"int256"},{"indexed":false,"internalType":"int256","name":"amount1","type":"int256"},{"indexed":false,"internalType":"uint160","name":"sqrtPriceX96","type":"uint160"},{"indexed":false,"internalType":"uint128","name":"liquidity","type":"uint128"},{"indexed":false,"internalType":"int24","name":"tick","type":"int24"}],"name":"Swap","type":"event"}]`
-
-	V2ABI, err = abi.JSON(strings.NewReader(v2AbiString))
-	if err != nil {
-		return nil, err
-	}
-	V3ABI, err = abi.JSON(strings.NewReader(v3AbiString))
-	if err != nil {
+	if err := initABIs(); err != nil {
 		return nil, err
 	}
 	return &Service{}, nil
+}
+
+// initABIs lazily parses the V2 and V3 ABIs once in a thread-safe manner.
+func initABIs() error {
+	initOnce.Do(func() {
+		v2AbiString := `[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"sender","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount0In","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"amount1In","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"amount0Out","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"amount1Out","type":"uint256"},{"indexed":true,"internalType":"address","name":"to","type":"address"}],"name":"Swap","type":"event"}]`
+		v3AbiString := `[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"sender","type":"address"},{"indexed":true,"internalType":"address","name":"recipient","type":"address"},{"indexed":false,"internalType":"int256","name":"amount0","type":"int256"},{"indexed":false,"internalType":"int256","name":"amount1","type":"int256"},{"indexed":false,"internalType":"uint160","name":"sqrtPriceX96","type":"uint160"},{"indexed":false,"internalType":"uint128","name":"liquidity","type":"uint128"},{"indexed":false,"internalType":"int24","name":"tick","type":"int24"}],"name":"Swap","type":"event"}]`
+
+		var err error
+		V2ABI, err = abi.JSON(strings.NewReader(v2AbiString))
+		if err != nil {
+			initErr = err
+			return
+		}
+		V3ABI, err = abi.JSON(strings.NewReader(v3AbiString))
+		if err != nil {
+			initErr = err
+			return
+		}
+	})
+	return initErr
 }
 
 // LogSwapV2 holds parsed data for a Uniswap V2 swap.


### PR DESCRIPTION
## Summary
- initialize ABIs using `sync.Once` to avoid race conditions
- add robust rollback logic to DBWriter commitBatch
- return errors from DBWriter save helpers
- add unit test for commitBatch success

## Testing
- `go test ./Database -run TestDBWriterCommitBatch -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686d4754cbac8323b016763b2a4cbf24